### PR TITLE
Makes RevTree compatible with Trac 1.2

### DIFF
--- a/revtree/api.py
+++ b/revtree/api.py
@@ -84,14 +84,15 @@ class RevtreeSystem(Component):
     enhancers = ExtensionPoint(IRevtreeEnhancer)
     optimizer = ExtensionOption('revtree', 'optimizer', IRevtreeOptimizer,
                                 'DefaultRevtreeOptimizer',
-        """Name of the component implementing `IRevtreeOptimizer`, which is
-        used for optimizing revtree element placements.""")
+        """Name of the component implementing `IRevtreeOptimizer`, 
+        which is used for optimizing revtree element placements.""")
 
     def get_revtree(self, repos, req):
         rm = RepositoryManager(self.env)
         reps = rm.get_all_repositories()
         for repo in reps:
-            if reps[repo]['type'] == 'svn':
+            rtype = reps[repo].get('type', None) or rm.default_repository_type
+            if rtype == 'svn':
                 break
         else:
             raise TracError("Revtree only supports Subversion repositories")

--- a/revtree/api.py
+++ b/revtree/api.py
@@ -15,8 +15,6 @@
 from trac.config import ExtensionOption
 from trac.core import *
 from trac.versioncontrol.api import RepositoryManager
-from trac.versioncontrol.svn_fs import \
-    SubversionRepository, SvnCachedRepository
 from revtree.svgview import SvgRevtree
 
 
@@ -91,10 +89,9 @@ class RevtreeSystem(Component):
 
     def get_revtree(self, repos, req):
         rm = RepositoryManager(self.env)
-        reps = rm.get_repositories()
+        reps = rm.get_all_repositories()
         for repo in reps:
-            repo = rm.get_repository(repo[0])
-            if isinstance(repo, (SubversionRepository, SvnCachedRepository)):
+            if reps[repo]['type'] == 'svn':
                 break
         else:
             raise TracError("Revtree only supports Subversion repositories")

--- a/revtree/model.py
+++ b/revtree/model.py
@@ -20,6 +20,7 @@ from trac.util.datefmt import utc
 from trac.util.text import to_unicode
 from trac.versioncontrol import NoSuchNode, Node as TracNode, \
     Changeset as TracChangeset
+from trac.versioncontrol.api import RepositoryManager
 import time
 
 
@@ -343,7 +344,16 @@ class Repository(object):
         self.log = env.log
 
         # Trac version control
-        self._crepos = self.env.get_repository()
+        rm = RepositoryManager(self.env)
+        repos = rm.get_all_repositories()
+        # select the first repo that is of 'svn' type
+        # Revtree is designed to work on envs with only one repo
+        for repo in repos:
+            if repos[repo]['type'] == 'svn':
+                self._crepos = rm.get_repository(repos[repo]['name'])
+                break
+        else:
+            raise TracError("Revtree only supports Subversion repositories")
 
         # Dictionary of changesets
         self._changesets = {}

--- a/revtree/web_ui.py
+++ b/revtree/web_ui.py
@@ -22,12 +22,13 @@ from trac.core import *
 from trac.perm import IPermissionRequestor
 from trac.util.datefmt import (format_datetime, pretty_timedelta, to_timestamp,
                                get_date_format_hint, parse_date)
+from trac.util.text import to_unicode
 from trac.util.translation import _
+from trac.versioncontrol.api import RepositoryManager
 from trac.web import IRequestFilter, IRequestHandler
 from trac.web.chrome import add_ctxtnav, add_script, add_stylesheet, \
     INavigationContributor, ITemplateProvider, add_script_data, add_warning, Chrome
 from trac.wiki import wiki_to_html
-from trac.util.text import to_unicode
 import cProfile
 import json
 import re
@@ -410,7 +411,14 @@ class RevtreeModule(Component):
 
         try:
             rev = int(req.args['logrev'])
-            repos = self.env.get_repository()
+            rm = RepositoryManager(self.env)
+            reps = rm.get_all_repositories()
+            for repo in reps:
+                if reps[repo]['type'] == 'svn':
+                    repos = rm.get_repository(reps[repo]['name'])
+                    break
+            else:
+                raise TracError("Revtree only supports Subversion repositories")
             chgset = repos.get_changeset(rev)
             wikimsg = wiki_to_html(to_unicode(chgset.message),
                                    self.env,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE = 'TracRevtreePlugin'
-VERSION = '2.1.2'
+VERSION = '2.1.3'
 
 setup(
     name=PACKAGE,
@@ -26,7 +26,7 @@ setup(
     license='BSD',
     url='https://github.com/sdelisle25/TracRevTreePlugin.git',
     keywords="trac revision svg graphical tree browser visual",
-    install_requires=['Trac>=1.0.0', 'Trac<1.2'],
+    install_requires=['Trac>=1.0.0', 'Trac<1.3'],
     packages=find_packages(exclude=['ez_setup', '*.tests*', '*.enhancers.*']),
     package_data={
         'revtree': [


### PR DESCRIPTION
-  test the repo object type instead of the `[Trac]/repository_type` option that has been removed
-  update requirement in `setup.py`
